### PR TITLE
[FABCAG-3] change regex to match FABCAG

### DIFF
--- a/.release/changelog.sh
+++ b/.release/changelog.sh
@@ -11,7 +11,7 @@ fi
 
 echo "## $2\n$(date)" >> CHANGELOG.new
 echo "" >> CHANGELOG.new
-git log ${OLD_VERSION}HEAD  --oneline | grep -v Merge | sed -e "s/\[\(FAB-[0-9]*\)\]/\[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/ \(FAB-[0-9]*\)/ \[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/\([0-9|a-z]*\)/* \[\1\](https:\/\/github.com\/hyperledger\/fabric-contract-api-go\/commit\/\1)/" >> CHANGELOG.new
+git log ${OLD_VERSION}HEAD  --oneline | grep -v Merge | sed -e "s/\[\(FABCAG-[0-9]*\)\]/\[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/ \(FABCAG-[0-9]*\)/ \[\1\](https:\/\/jira.hyperledger.org\/browse\/\1\)/" -e "s/\([0-9|a-z]*\)/* \[\1\](https:\/\/github.com\/hyperledger\/fabric-contract-api-go\/commit\/\1)/" >> CHANGELOG.new
 echo "" >> CHANGELOG.new
 cat CHANGELOG.md >> CHANGELOG.new
 mv -f CHANGELOG.new CHANGELOG.md


### PR DESCRIPTION
[[FABCAG-3]](https://jira.hyperledger.org/browse/FABCAG-3)

Update changelog.sh to use new project format. Tested locally using commit [b02adca](https://github.com/hyperledger/fabric-contract-api-go/commit/b02adca) and got expected result with link to JIRA

Signed-off-by: Andrew Hurt <andrew.hurt1@ibm.com>