### PR TITLE
Change release check script to ignore beta release in check for changelog

### DIFF
--- a/.azure-pipelines/scripts/release-checks.sh
+++ b/.azure-pipelines/scripts/release-checks.sh
@@ -5,6 +5,10 @@
 
 set -e
 
+if [[ $1 == *"beta"* ]]; then
+    exit 0
+fi
+
 if ! cat ./CHANGELOG.md | grep -q "## $1"; then
     echo "Changelog does not contain tag. Have you run ./.release/changelog.sh?"
     exit 1


### PR DESCRIPTION
[[FABCAG-4]](https://jira.hyperledger.org/browse/FABCAG-4)

Add check in release checks to ensure tags containing word beta are not checked against the changelog