### PR TITLE
[FABCAG-19] Fix minor bugs in tutorial

### DIFF
--- a/tutorials/getting-started.md
+++ b/tutorials/getting-started.md
@@ -155,7 +155,7 @@ type SimpleContract struct {
 }
 
 // Create adds a new key with value to the world state
-func (sc *SimpleContract) Create(ctx *contractapi.TransactionContextInterface, key string, value string) error {
+func (sc *SimpleContract) Create(ctx contractapi.TransactionContextInterface, key string, value string) error {
     existing, err := ctx.GetStub().GetState(key)
 
     if err != nil {
@@ -176,7 +176,7 @@ func (sc *SimpleContract) Create(ctx *contractapi.TransactionContextInterface, k
 }
 
 // Update changes the value with key in the world state
-func (sc *SimpleContract) Update(ctx *contractapi.TransactionContextInterface, key string, value string) error {
+func (sc *SimpleContract) Update(ctx contractapi.TransactionContextInterface, key string, value string) error {
     existing, err := ctx.GetStub().GetState(key)
 
     if err != nil {

--- a/tutorials/managing-objects.md
+++ b/tutorials/managing-objects.md
@@ -162,7 +162,7 @@ func (cc *ComplexContract) UpdateValue(ctx CustomTransactionContextInterface, id
 }
 ```
 
-Add a final function to allow a transaction caller to read your asset from the world state.
+Add a further function to allow a transaction caller to read your asset from the world state.
 
 ```
 // GetAsset returns the basic asset with id given from the world state
@@ -182,6 +182,15 @@ func (cc *ComplexContract) GetAsset(ctx CustomTransactionContextInterface, id st
 	}
 
 	return ba, nil
+}
+```
+
+Finally define a `GetEvaluateTransactions` functions for your new contract. Make this function return `GetAsset` since this is the only function that does not write to the world state.
+
+```
+// GetEvaluateTransactions returns functions of ComplexContract not to be tagged as submit
+func (cc *ComplexContract) GetEvaluateTransactions() []string {
+	return []string{"GetAsset"}
 }
 ```
 

--- a/tutorials/using-advanced-features.md
+++ b/tutorials/using-advanced-features.md
@@ -205,20 +205,20 @@ Chaincode created using the contractapi package automatically has generated for 
 
 In Go the metadata is produced automatically for you using reflection, due to limitations of Go reflection the parameter names of functions in the metadata will not match the chaincode code but will instead use param0, param1, ..., paramN.
 
-You can view the metadata for your chaincode by querying the system chaincode 'org.hyperledger.fabric' and its function 'getMetadata'. This is also how you view the metadata of chaincodes written in Node and Java (as long as they follow the [Fabric programming model](https://hyperledger-fabric.readthedocs.io/en/release-1.4/whatsnew.html#improved-programming-model-for-developing-applications)).
+You can view the metadata for your chaincode by querying the system chaincode 'org.hyperledger.fabric' and its function 'GetMetadata'. This is also how you view the metadata of chaincodes written in Node and Java (as long as they follow the [Fabric programming model](https://hyperledger-fabric.readthedocs.io/en/release-1.4/whatsnew.html#improved-programming-model-for-developing-applications)).
 
 To see the metadata of the chaincode made in this tutorial issue the following command in the CLI docker terminal:
 
 ```
-peer chaincode query -n mycc -c '{"Args":["org.hyperledger.fabric:getMetadata"]}' -C myc
+peer chaincode query -n mycc -c '{"Args":["org.hyperledger.fabric:GetMetadata"]}' -C myc
 ```
 
 Notice in the chaincode that contract functions have a property `tag` which contains a string array with one element `submit`. A submit tag is used in the metadata to indicate that the function when called as part of a transaction should be "submitted" rather than "evaluated". Submitting a transaction (invoking) means that can be written to the world state, evaluating (querying) runs the function as read only. The `Read` function of `SimpleContract` is tagged as `submit` however in the code it never writes to the world state. This is as all contract functions are tagged as `submit` by default when the contractapi package is used to create chaincode. You must therefore explicitly mark which functions are for evaluating rather than submitting. Chaincode created using the contractapi calls the `GetEvaluateTransactions()` function of a contract (should it exist) to retrieve a list of name of functions that are evaluate rather than submit.
 
-Define a `GetEvaluateTransactions` function on `SimpleChaincode` and have it return `Read` as the only element of the string array:
+Define a `GetEvaluateTransactions` function on `SimpleContract` and have it return `Read` as the only element of the string array:
 
 ```
-// GetEvaluateTransactions returns functions of SimpleChaincode not to be tagged as submit
+// GetEvaluateTransactions returns functions of SimpleContract not to be tagged as submit
 func (sc *SimpleContract) GetEvaluateTransactions() []string {
 	return []string{"Read"}
 }


### PR DESCRIPTION
[FABCAG-19](https://jira.hyperledger.org/browse/FABCAG-19)

Fixes:
- incorrect type reference for context in getting started.
- out of step casing for getMetadata in using advanced features
- referal to SimpleChaincode instead of contract in using advanced features
- missing GetEvaluateTransactions function in complex objects