### PR TITLE
[FABCAG-21] Update tutorials based on user feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ There’s always plenty to do! Check the documentation on
 ## Documentation
 Documentation for all packages within this repo can be found [here](http://godoc.org/github.com/hyperledger/fabric-contract-api-go)
 
-## Tutorial
-Tutorials for how to create smart contracts using packages in this repo can be [here](./tutorials)
+## Tutorials
+Tutorials for how to create smart contracts using packages in this repo can be found [here](./tutorials)
 
 A sample chaincode built using packages from this repo can be found in [fabric-samples](https://github.com/hyperledger/fabric-samples/tree/master/chaincode/fabcar/go)
 

--- a/tutorials/getting-started.md
+++ b/tutorials/getting-started.md
@@ -12,12 +12,24 @@
 ## Prerequisites
 This tutorial will assume you have:
 - A clone of [fabric-samples](https://github.com/hyperledger/fabric-samples)
-- [Go 1.12+](https://golang.org/doc/install)
+- [Go 1.13.x](https://golang.org/doc/install)
 - [Docker](https://docs.docker.com/install/)
 - [Docker compose](https://docs.docker.com/compose/install/)
 
 ## Housekeeping
-Since this tutorial will make use of fabric-samples' `chaincode-docker-devmode` setup you should be developing within `fabric-samples/chaincode`. Make a folder inside `fabric-samples/chaincode` called `contract-tutorial` and open your preferred editor there. In your terminal run the command `go mod init github.com/hyperledger/fabric-samples/chaincode/contract-tutorial` to setup go modules. You can then run `go get -u github.com/hyperledger/fabric-contract-api-go` to get the latest release of fabric-contract-api-go for use in your chaincode.
+Since this tutorial will make use of fabric-samples' `chaincode-docker-devmode` setup you should be developing within `fabric-samples/chaincode`. Make a folder inside `fabric-samples/chaincode` called `contract-tutorial` and open your preferred editor there. In your terminal run the command
+
+```
+go mod init github.com/hyperledger/fabric-samples/chaincode/contract-tutorial
+```
+
+to setup go modules. You can then run
+ 
+```
+go get -u github.com/hyperledger/fabric-contract-api-go
+```
+
+to get the latest release of fabric-contract-api-go for use in your chaincode.
 
 ## Declaring a contract
 The contractapi generates chaincode by taking one or more "contracts" that it bundles into a running chaincode. The first thing we will do here is declare a contract for use in our chaincode. This contract will be simple, handling the reading and writing of strings to and from the world state. All contracts for use in chaincode must implement the [contractapi.ContractInterface](https://godoc.org/github.com/hyperledger/fabric-contract-api-go/contractapi#ContractInterface). The easiest way to do this is to embed the `contractapi.Contract` struct within your own contract which will provide default functionality for meeting this interface.
@@ -242,8 +254,8 @@ Once you have your chaincode, to make it callable via transactions you must star
 
 ```
     if err := cc.Start(); err != nil {
-		panic(err.Error())
-	}
+        panic(err.Error())
+    }
 ```
 
 Your `main.go` file should now look like this:
@@ -265,8 +277,8 @@ func main() {
     }
 
     if err := cc.Start(); err != nil {
-		panic(err.Error())
-	}
+        panic(err.Error())
+    }
 }
 ```
 
@@ -275,7 +287,7 @@ Open a terminal to where you have cloned `fabric-samples` and cd into the `chain
 
 Startup the simple fabric network using:
 
-> Note: this command will not exit
+> Note: this command will continuously print output and will not exit
 
 ```
 docker-compose -f docker-compose-simple.yaml up
@@ -300,6 +312,7 @@ cd contract-tutorial
 Once in that folder you must build your chaincode program for running. You must also 'vendor' the imports for the go program as the peer will be missing these packages.
 
 > Note: ensure you have the 2.x.x version of the fabric docker images or the `go build` command will fail.
+> Note: ensure you have the correct permissions configured on your contract-tutorial folder for docker to create files there. Running `chmod -R 766` should set the correct permission levels.
 
 ```
 go mod vendor

--- a/tutorials/managing-objects.md
+++ b/tutorials/managing-objects.md
@@ -13,7 +13,7 @@ This tutorial will assume you have:
 - Completed [Using advanced features](./using-advance-features.md)
 
 ## Defining an object
-The chaincode written so far contains a single contract and purely works with taking and returning string values. As mentioned in the [first tutorial](./getting-started.md) functions can take and return many types including structs (and pointers to structs). This tutorial will create a contract which handles the management of an object.
+The chaincode written so far contains a single contract and purely works with taking and returning string values. As mentioned in the [first tutorial](./getting-started.md) functions can take and return many types including structs (and pointers to structs). This tutorial will create a contract which handles the management of an object to show how the contract API handles the taking and returning of non-string types.
 
 Create a new file in your `contract-tutorial` folder called `basic-asset.go`. In here we will create the object to manage, in this case we will call it `BasicAsset`. 
 
@@ -226,7 +226,7 @@ You now have a chaincode consisting of two contracts.
 > Note: since both contracts are part of the same chaincode they can read and write to the same keys in the ledger.
 
 ## Using a custom name for your contracts
-When there was only one contract in the chaincode, calling it consisted of just passing the function name. With multiple it is now necessary to know the contract name and namespace calls in the format `<CONTRACT_NAME>:<FUNCTION_NAME>`. By default the contracts can be referenced by their struct name, in this case they would be `SimpleContract` and `ComplexContract`. The first contract passed to the `NewChaincode` function is also the default contract and therefore its functions can be called without namespacing. Sometimes it is desirable to to use custom names for contracts. The chaincode calls `GetName` on the contract when it is created to determine the name of the contract and since both our contracts embed the `contractapi.Contract` struct, we can set the value to be returned from this function by setting the name property of the contracts before calling `NewChaincode`.
+When there was only one contract in the chaincode, calling it consisted of just passing the function name. With multiple it is now necessary to know the contract name and namespace calls in the format `<CONTRACT_NAME>:<FUNCTION_NAME>`. By default the contracts can be referenced by their struct name, in this case they would be `SimpleContract` and `ComplexContract`. The first contract passed to the `NewChaincode` function is also the default contract and therefore its functions can be called without namespacing. Sometimes it is desirable to to use custom names for contracts. The chaincode calls `GetName` on the contract when it is created to determine the name of the contract and since both our contracts embed the `contractapi.Contract` struct, we can set the value to be returned from this function by setting the name property of the contracts before calling `NewChaincode` in your `main` function.
 
 ```
 simpleContract.Name = "org.example.com.SimpleContract"
@@ -234,7 +234,7 @@ simpleContract.Name = "org.example.com.SimpleContract"
 complexContract.Name = "org.example.com.ComplexContract"
 ```
 
-You can then set the default contract to be the complex contract by setting the `DefaultContract` property of the chaincode to be the name of the complex chaincode. Do this after checking the error value returned by `NewChaincode` or you may get a runtime error as if an error occurs chaincode will be `nil`.
+You can then set the default contract to be the complex contract by, in your `main` function, setting the `DefaultContract` property of the chaincode to be the name of the complex chaincode. Do this after checking the error value returned by `NewChaincode` or you may get a runtime error as if an error occurs chaincode will be `nil`.
 
 ```
 cc.DefaultContract = complexContract.GetName()
@@ -245,18 +245,22 @@ If you have torn down your network from the previous tutorials you can run throu
 ### Simple contract
 
 ```
-peer chaincode invoke -n mycc -c '{"Args":["org.example.com.SimpleContract:Create", "KEY_1", "VALUE_1"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["org.example.com.SimpleContract:Create", "KEY_3", "VALUE_1"]}' -C myc
 
-peer chaincode invoke -n mycc -c '{"Args":["org.example.com.SimpleContract:Update", "KEY_1", "VALUE_2"]}' -C myc
+peer chaincode invoke -n mycc -c '{"Args":["org.example.com.SimpleContract:Update", "KEY_3", "VALUE_2"]}' -C myc
 
-peer chaincode query -n mycc -c '{"Args":["org.example.com.SimpleContract:Read", "KEY_1"]}' -C myc
+peer chaincode query -n mycc -c '{"Args":["org.example.com.SimpleContract:Read", "KEY_3"]}' -C myc
 ```
 
 ### Complex contract
 
-```
-peer chaincode invoke -n mycc -c '{"Args":["org.example.com.ComplexContract:NewAsset", "ASSET_1", "{\"forename\": \"blue\", \"surname\": \"conga\"}", "100"]}' -C myc
+> You can call the complex contract both using its name or by just passing the name of its functions since it is now the default
 
+```
+# call without passing name
+peer chaincode invoke -n mycc -c '{"Args":["NewAsset", "ASSET_1", "{\"forename\": \"blue\", \"surname\": \"conga\"}", "100"]}' -C myc
+
+# call passing name
 peer chaincode invoke -n mycc -c '{"Args":["org.example.com.ComplexContract:UpdateOwner", "ASSET_1", "{\"forename\": \"green\", \"surname\": \"conga\"}"]}' -C myc
 
 peer chaincode invoke -n mycc -c '{"Args":["org.example.com.ComplexContract:UpdateValue", "ASSET_1", "300"]}' -C myc


### PR DESCRIPTION
[FABCAG-21](https://jira.hyperledger.org/browse/FABCAG-21)

- Clarification that docker-compose command will print output continuously
- Clarification on where to add custom contract interface
- Bumped Go version requirement to 1.13 to fix go get error and move in line with fabric
- Made struct instance identifier unique in example functions vs custom context (both were previously c)
- Added note on permission issues when running go mod vendor
- Added extra command run to show difference between custom unknown and standard
- Clarified that metadata has no impact on client transaction submittal type choice (invoke vs submit)
- Fixed bad alignement of chaincode start if statement
- Updated commands for complex object to not use namespacing to show it now as default
- Updated key in simple contract commands of final tutorial to not clash with key from first tutorial