### PR TITLE
[FABCAG-7] introduce ledger [FABCAG-9] introduce collection

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/gobuffalo/packd v0.3.0/go.mod h1:zC7QkmNkYVGKPw4tHpBQ+ml7W/3tIebgeo1b
 github.com/gobuffalo/packr v1.30.1 h1:hu1fuVR3fXEZR7rXNW3h8rqSML8EVAf6KNm0NKO/wKg=
 github.com/gobuffalo/packr v1.30.1/go.mod h1:ljMyFO2EcrnzsHsN99cvbq055Y9OhRrIaviy289eRuk=
 github.com/gobuffalo/packr/v2 v2.5.1/go.mod h1:8f9c96ITobJlPzI44jj+4tHnEKNt0xXWSVlXRN9X1Iw=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=

--- a/ledgerapi/collection.go
+++ b/ledgerapi/collection.go
@@ -1,0 +1,109 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/hyperledger/fabric-contract-api-go/contractapi"
+)
+
+// WorldStateIdentifier the collection name to be used for the world state
+const WorldStateIdentifier = "worldstate"
+
+// CollectionInterface placeholder
+type CollectionInterface interface {
+	GetState(string) (StateInterface, error)
+	GetStates(QueryInterface) (StateIteratorInterface, error)
+	CreateState(string, []byte) error
+	UpdateState(string, []byte) error
+	DeleteState(string) error
+}
+
+// Collection placeholder
+type Collection struct {
+	name string
+	ctx  contractapi.TransactionContextInterface
+}
+
+// GetState placeholder
+func (c *Collection) GetState(key string) (StateInterface, error) {
+	errMsg := fmt.Sprintf("Failed to get state %s in collection %s.", key, c.name)
+
+	_, err := c.ctx.GetStub().GetState(key)
+
+	if err != nil {
+		return nil, fmt.Errorf("%s %s", errMsg, err.Error())
+	}
+
+	return nil, errors.New("Not yet implemented")
+}
+
+// GetStates placeholder
+func (c *Collection) GetStates(QueryInterface) (StateIteratorInterface, error) {
+	return nil, errors.New("Not yet implemented")
+}
+
+// CreateState adds a state with a given key to the collection. Errors if the key already exists
+func (c *Collection) CreateState(key string, data []byte) error {
+	errMsg := fmt.Sprintf("Failed to create new state %s in collection %s.", key, c.name)
+
+	stub := c.ctx.GetStub()
+
+	bytes, err := stub.GetState(key)
+
+	if err != nil {
+		return fmt.Errorf("%s %s", errMsg, err.Error())
+	} else if bytes != nil {
+		return fmt.Errorf("%s State already exists for key", errMsg)
+	}
+
+	err = stub.PutState(key, data)
+
+	if err != nil {
+		return fmt.Errorf("%s %s", errMsg, err.Error())
+	}
+
+	return nil
+}
+
+// UpdateState updates a the value at a the given key in the collection. Errors if that key does
+// not yet exist
+func (c *Collection) UpdateState(key string, data []byte) error {
+	errMsg := fmt.Sprintf("Failed to update state %s in collection %s.", key, c.name)
+
+	stub := c.ctx.GetStub()
+
+	bytes, err := stub.GetState(key)
+
+	if err != nil {
+		return fmt.Errorf("%s %s", errMsg, err.Error())
+	} else if bytes == nil {
+		return fmt.Errorf("%s State does not exist for key", errMsg)
+	}
+
+	err = stub.PutState(key, data)
+
+	if err != nil {
+		return fmt.Errorf("%s %s", errMsg, err.Error())
+	}
+
+	return err
+}
+
+// DeleteState removes the value at the given key from the world state
+func (c *Collection) DeleteState(key string) error {
+	errMsg := fmt.Sprintf("Failed to delete state %s in collection %s.", key, c.name)
+
+	stub := c.ctx.GetStub()
+
+	err := stub.DelState(key)
+
+	if err != nil {
+		return fmt.Errorf("%s %s", errMsg, err.Error())
+	}
+
+	return err
+}

--- a/ledgerapi/collection_test.go
+++ b/ledgerapi/collection_test.go
@@ -1,0 +1,98 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ================================
+// HELPERS
+// ================================
+
+func configureCollection() *Collection {
+	ctx, _ := configureStub()
+
+	collection := new(Collection)
+	collection.ctx = ctx
+	collection.name = "mycollection"
+
+	return collection
+}
+
+// ================================
+// TESTS
+// ================================
+
+func TestGetState(t *testing.T) {
+	collection := configureCollection()
+
+	si, err := collection.GetState("readbad")
+
+	assert.EqualError(t, err, fmt.Sprintf("Failed to get state readbad in collection mycollection. %s", getStateError), "should error when stub GetState errors")
+	assert.Nil(t, si, "should not return state interface when stub GetState fails to return a value")
+}
+
+func TestGetStates(t *testing.T) {
+	// not yet implemented
+}
+
+func TestCreateState(t *testing.T) {
+	collection := configureCollection()
+	stub := (collection.ctx.GetStub().(*MockStub))
+
+	var err error
+
+	err = collection.CreateState("readbad", []byte("value"))
+	assert.EqualError(t, err, fmt.Sprintf("Failed to create new state readbad in collection mycollection. %s", getStateError), "should error when stub GetState errors")
+
+	err = collection.CreateState("existingkey", []byte("value"))
+	assert.EqualError(t, err, "Failed to create new state existingkey in collection mycollection. State already exists for key", "should error when key exists")
+	stub.AssertNotCalled(t, "PutState", "existingkey", []byte("value"))
+
+	err = collection.CreateState("putbadmissing", []byte("value"))
+	assert.EqualError(t, err, fmt.Sprintf("Failed to create new state putbadmissing in collection mycollection. %s", putStateError), "should error when stub PutState errors")
+
+	err = collection.CreateState("missingkey", []byte("value"))
+	assert.Nil(t, err, "should not error when key is new")
+	stub.AssertCalled(t, "PutState", "missingkey", []byte("value"))
+}
+
+func TestUpdateState(t *testing.T) {
+	collection := configureCollection()
+	stub := (collection.ctx.GetStub().(*MockStub))
+
+	var err error
+
+	err = collection.UpdateState("readbad", []byte("value"))
+	assert.EqualError(t, err, fmt.Sprintf("Failed to update state readbad in collection mycollection. %s", getStateError), "should error when stub GetState errors")
+
+	err = collection.UpdateState("missingkey", []byte("value"))
+	assert.EqualError(t, err, "Failed to update state missingkey in collection mycollection. State does not exist for key", "should error when key exists")
+	stub.AssertNotCalled(t, "PutState", "missingkey", []byte("value"))
+
+	err = collection.UpdateState("putbadexisting", []byte("value"))
+	assert.EqualError(t, err, fmt.Sprintf("Failed to update state putbadexisting in collection mycollection. %s", putStateError), "should error when stub PutState errors")
+
+	err = collection.UpdateState("existingkey", []byte("value"))
+	assert.Nil(t, err, "should not error when key exists")
+	stub.AssertCalled(t, "PutState", "existingkey", []byte("value"))
+}
+
+func TestDeleteState(t *testing.T) {
+	collection := configureCollection()
+	stub := (collection.ctx.GetStub().(*MockStub))
+
+	var err error
+
+	err = collection.DeleteState("delbad")
+	assert.EqualError(t, err, fmt.Sprintf("Failed to delete state delbad in collection mycollection. %s", delStateError), "should error when stub DelState errors")
+
+	err = collection.DeleteState("existingkey")
+	assert.Nil(t, err, "should not error when can delete key")
+	stub.AssertCalled(t, "DelState", "existingkey")
+}

--- a/ledgerapi/ledger.go
+++ b/ledgerapi/ledger.go
@@ -1,0 +1,41 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+import "github.com/hyperledger/fabric-contract-api-go/contractapi"
+
+// LedgerInterface defines functions of a ledger
+type LedgerInterface interface {
+	// GetCollection returns a collection with the passed name
+	GetCollection(string) CollectionInterface
+
+	// GetDefaultCollection returns a collection representing the world state
+	GetDefaultCollection() CollectionInterface
+}
+
+// Ledger an implementation of LedgerInterface to provide access to collections
+type Ledger struct {
+	ctx contractapi.TransactionContextInterface
+}
+
+// GetCollection returns the collection identified by the passed name
+func (l *Ledger) GetCollection(name string) CollectionInterface {
+	collection := new(Collection)
+	collection.name = name
+
+	return collection
+}
+
+// GetDefaultCollection returns the collection identified by the WorldStateIdentifier
+func (l *Ledger) GetDefaultCollection() CollectionInterface {
+	return l.GetCollection(WorldStateIdentifier)
+}
+
+// GetLedger returns an implementation of the LedgerInterface setup to use the passed context
+func GetLedger(ctx contractapi.TransactionContextInterface) LedgerInterface {
+	ledger := new(Ledger)
+	ledger.ctx = ctx
+
+	return ledger
+}

--- a/ledgerapi/ledger_test.go
+++ b/ledgerapi/ledger_test.go
@@ -1,0 +1,46 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetLedger(t *testing.T) {
+	ctx := new(MockContext)
+	ctx.prop = "value"
+
+	expectedLedger := new(Ledger)
+	expectedLedger.ctx = ctx
+
+	actualLedger := GetLedger(ctx).(*Ledger)
+
+	assert.Equal(t, expectedLedger, actualLedger, "should return an instance of Ledger")
+}
+
+func TestGetCollection(t *testing.T) {
+	ctx := new(MockContext)
+
+	expectedCollection := new(Collection)
+	expectedCollection.name = "some name"
+
+	ledger := GetLedger(ctx)
+
+	actualCollection := ledger.GetCollection("some name")
+
+	assert.Equal(t, expectedCollection, actualCollection, "should return a collection using the name passed")
+}
+
+func TestGetDefaultCollection(t *testing.T) {
+	ctx := new(MockContext)
+
+	ledger := GetLedger(ctx)
+
+	expectedCollection := ledger.GetCollection(WorldStateIdentifier)
+	actualCollection := ledger.GetDefaultCollection()
+
+	assert.Equal(t, expectedCollection, actualCollection, "should return a collection using the world state identifier")
+}

--- a/ledgerapi/query.go
+++ b/ledgerapi/query.go
@@ -1,0 +1,7 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+// QueryInterface placeholder
+type QueryInterface interface{}

--- a/ledgerapi/shared_test.go
+++ b/ledgerapi/shared_test.go
@@ -1,0 +1,78 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+import (
+	"errors"
+
+	"github.com/hyperledger/fabric-chaincode-go/pkg/cid"
+	"github.com/hyperledger/fabric-chaincode-go/shim"
+	"github.com/stretchr/testify/mock"
+)
+
+const getStateError = "collection get error"
+const putStateError = "collection put error"
+const delStateError = "collection del error"
+
+type MockStub struct {
+	shim.ChaincodeStubInterface
+	mock.Mock
+}
+
+func (ms *MockStub) GetState(key string) ([]byte, error) {
+	args := ms.Called(key)
+
+	return args.Get(0).([]byte), args.Error(1)
+}
+
+func (ms *MockStub) PutState(key string, value []byte) error {
+	args := ms.Called(key, value)
+
+	return args.Error(0)
+}
+
+func (ms *MockStub) DelState(key string) error {
+	args := ms.Called(key)
+
+	return args.Error(0)
+}
+
+type MockContext struct {
+	mock.Mock
+	prop string
+}
+
+func (mc *MockContext) GetStub() shim.ChaincodeStubInterface {
+	args := mc.Called()
+
+	return args.Get(0).(*MockStub)
+}
+
+func (mc *MockContext) GetClientIdentity() cid.ClientIdentity {
+	return nil
+}
+
+func configureStub() (*MockContext, *MockStub) {
+	var nilBytes []byte
+
+	ms := new(MockStub)
+	ms.On("GetState", "readbad").Return(nilBytes, errors.New(getStateError))
+	ms.On("GetState", "missingkey").Return(nilBytes, nil)
+	ms.On("GetState", "existingkey").Return([]byte("some value"), nil)
+	ms.On("GetState", "putbadmissing").Return(nilBytes, nil)
+	ms.On("GetState", "putbadexisting").Return([]byte("some value"), nil)
+
+	ms.On("PutState", "putbadmissing", mock.AnythingOfType("[]uint8")).Return(errors.New(putStateError))
+	ms.On("PutState", "putbadexisting", mock.AnythingOfType("[]uint8")).Return(errors.New(putStateError))
+	ms.On("PutState", "missingkey", mock.AnythingOfType("[]uint8")).Return(nil)
+	ms.On("PutState", "existingkey", mock.AnythingOfType("[]uint8")).Return(nil)
+
+	ms.On("DelState", "delbad").Return(errors.New(delStateError))
+	ms.On("DelState", "existingkey").Return(nil)
+
+	mc := new(MockContext)
+	mc.On("GetStub").Return(ms)
+
+	return mc, ms
+}

--- a/ledgerapi/state.go
+++ b/ledgerapi/state.go
@@ -1,0 +1,10 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ledgerapi
+
+// StateInterface placeholder
+type StateInterface interface{}
+
+// StateIteratorInterface placeholder
+type StateIteratorInterface interface{}


### PR DESCRIPTION
Partially resolves:
[FABCAG-7](https://jira.hyperledger.org/browse/FABCAG-7)
[FABCAG-9](https://jira.hyperledger.org/browse/FABCAG-9)

Introduces:
- Ledger Object
- Collections Object

Does not resolve:
- integration tests, these will be built out once the underlying interaction with the world state is complete