### PR TITLE
[FABCAG-29] Added Azure devops pipeline build status badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Hyperledger Fabric Go Contract API
 
+[![Build Status](https://dev.azure.com/Hyperledger/Fabric-Contract-API-Go/_apis/build/status/Fabric-Contract-API-Go?branchName=master)](https://dev.azure.com/Hyperledger/Fabric-Contract-API-Go/_build/latest?definitionId=48&branchName=master)
 [![](http://godoc.org/github.com/hyperledger/fabric-contract-api-go?status.svg)](http://godoc.org/github.com/hyperledger/fabric-contract-api-go)
 
 This repository contains the packages for the implementation of the contract API for use in Go chaincode running on Fabric v2.1


### PR DESCRIPTION
Added the Azure pipeline build status for `Fabric-contract-api-Go`.