### PR TITLE
[FABCAG-33] Skip unexported fields in struct validation

### DIFF
--- a/internal/types_handler.go
+++ b/internal/types_handler.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"unicode"
 
 	"github.com/hyperledger/fabric-contract-api-go/internal/types"
 	"github.com/hyperledger/fabric-contract-api-go/internal/utils"
@@ -41,7 +42,14 @@ func structOfValidType(obj reflect.Type, additionalTypes []reflect.Type) error {
 	}
 
 	for i := 0; i < obj.NumField(); i++ {
-		err := typeIsValid(obj.Field(i).Type, additionalTypes, false)
+		field := obj.Field(i)
+
+		if runes := []rune(field.Name); len(runes) > 0 && !unicode.IsUpper(runes[0]) && field.Tag.Get("metadata") == "" {
+			// Skip validation for private fields, except those tagged as metadata
+			continue
+		}
+
+		err := typeIsValid(field.Type, additionalTypes, false)
 
 		if err != nil {
 			return err

--- a/internal/types_handler_test.go
+++ b/internal/types_handler_test.go
@@ -30,6 +30,16 @@ type BadStruct struct {
 	Prop2 complex64 `json:"prop2"`
 }
 
+type goodStructWithBadPrivateFields struct {
+	unexported complex64
+	Valid      int `json:"Valid"`
+}
+
+type badStructWithMetadataPrivateFields struct {
+	Prop  string    `json:"prop"`
+	class complex64 `metadata:"class"`
+}
+
 type UsefulInterface interface{}
 
 var badType = reflect.TypeOf(complex64(1))
@@ -117,6 +127,10 @@ func TestStructOfValidType(t *testing.T) {
 	assert.Nil(t, structOfValidType(reflect.TypeOf(goodStruct{}), []reflect.Type{}), "should not return an error for a valid struct")
 
 	assert.EqualError(t, structOfValidType(reflect.TypeOf(BadStruct{}), []reflect.Type{}), fmt.Sprintf(basicErr, badType.String(), listBasicTypes()), "should return an error for invalid struct")
+
+	assert.Nil(t, structOfValidType(reflect.TypeOf(goodStructWithBadPrivateFields{}), []reflect.Type{}), "should not return an error for unexported fields")
+
+	assert.EqualError(t, structOfValidType(reflect.TypeOf(badStructWithMetadataPrivateFields{}), []reflect.Type{}), fmt.Sprintf(basicErr, badType.String(), listBasicTypes()), "should return an error for invalid metadata private fields")
 }
 
 func TestTypeIsValid(t *testing.T) {


### PR DESCRIPTION
## Description of the issue

When adding a new contract, the interface if [derived from reflection](https://github.com/hyperledger/fabric-contract-api-go/blob/0f7ed0984df34ab0f029f824666a514896fc17c3/contractapi/contract_chaincode.go#L307) of the contract's method.
This will [check](https://github.com/hyperledger/fabric-contract-api-go/blob/0f7ed0984df34ab0f029f824666a514896fc17c3/internal/contract_function.go#L339) that outputs of the method are valid, and recursively descend into structs.

Reflection will iterate over unexported fields, which are of no interest since they won't be part of the contract's response.

The new [test case](https://github.com/hyperledger/fabric-contract-api-go/compare/master...mblottiere:skip-unexported-fields?expand=1#diff-89b1aaa9ce798bb3aa66de3ce0644eeef3f46a5153619e56701f0a56f3d88257R33) illustrates the issue; it fails without this commit.

## Motivation for this change

There are three main reasons why it would be preferable to skip the unexported fields:
- Since they don't have any role in the public interface of the contract, we might as well ignore them in the validation
- Recursively descending into structs can be costly, skipping fields would reduce the number of iterations
- One might want to use third party structs as return type (protobuf generated ones for instance), which is currently prevented by the failing validation of unexported fields.