### PR TITLE
Update vulnerability scan Go version

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.17.x
+          go-version: 1.18.x
       - name: Scan
         run: |
           go list -json -deps ./... | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth


### PR DESCRIPTION
govulncheck requires Go 1.18

Signed-off-by: James Taylor <jamest@uk.ibm.com>