### PR TITLE
Only use govulncheck for vulnerability scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -6,17 +6,16 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan:
-    runs-on: ubuntu-20.04
+  govulncheck:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.x
+          go-version: '^1.20'
           check-latest: true
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - name: Scan
-        run: |
-          go list -json -deps ./... | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth
-          go install golang.org/x/vuln/cmd/govulncheck@latest
-          govulncheck ./...
+        run: govulncheck ./...


### PR DESCRIPTION
Govulncheck provides more intelligent scanning and is lighter weight than Nancy. Remove use of nancy in vulnerability scan.