### PR TITLE
Allow schema types with the same name from different packages

### DIFF
--- a/internal/functionaltests/contracts/complexcontract/contract-metadata/metadata.json
+++ b/internal/functionaltests/contracts/complexcontract/contract-metadata/metadata.json
@@ -17,7 +17,7 @@
                         }
                     ],
                     "returns": {
-                        "$ref": "#/components/schemas/BasicObject"
+                        "$ref": "#/components/schemas/github.com.hyperledger.fabric-contract-api-go.internal.functionaltests.contracts.complexcontract.BasicObject"
                     },
                     "tag": [
                         "evaluate",
@@ -59,7 +59,7 @@
                         {
                             "name": "param1",
                             "schema": {
-                                "$ref": "#/components/schemas/BasicOwner"
+                                "$ref": "#/components/schemas/github.com.hyperledger.fabric-contract-api-go.internal.functionaltests.contracts.complexcontract.BasicOwner"
                             }
                         },
                         {
@@ -99,7 +99,7 @@
                         {
                             "name": "param1",
                             "schema": {
-                                "$ref": "#/components/schemas/BasicOwner"
+                                "$ref": "#/components/schemas/github.com.hyperledger.fabric-contract-api-go.internal.functionaltests.contracts.complexcontract.BasicOwner"
                             }
                         }
                     ],

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -74,7 +74,7 @@ func TestBoolType(t *testing.T) {
 	assert.False(t, val.Interface().(bool), "should have returned the boolean false for blank value")
 
 	val, err = boolTypeVar.Convert("non bool")
-	assert.Error(t, fmt.Errorf(convertError, "non bool"), "should return error for invalid bool value")
+	assert.Error(t, err, fmt.Errorf(convertError, "non bool"), "should return error for invalid bool value")
 	assert.Equal(t, reflect.Value{}, val, "should have returned the blank value for non bool")
 }
 

--- a/serializer/internal/test_data.go
+++ b/serializer/internal/test_data.go
@@ -1,0 +1,8 @@
+// Copyright the Hyperledger Fabric contributors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package internal
+
+type SimpleStruct struct {
+	Prop1 string `json:"Prop1"`
+}


### PR DESCRIPTION
Previously the short type name was used as a schema key. This meant that types of the same name from different packages would overwrite each other in the map of schema type definitions, causing unexpected serialization errors. Now the fully qualified (package + type) name is used so that entries for types with the same name from different packages are unique.