### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,19 +12,18 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-    - uses: actions/setup-go@v4
+    - uses: actions/setup-go@v5
       with:
         go-version: '1.19'
-    - uses: actions/setup-node@v3
+    - uses: actions/setup-node@v4
       with:
         node-version: 16
         registry-url: 'https://npm.pkg.github.com'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: install Tools
       run: |
-
         go install honnef.co/go/tools/cmd/staticcheck@latest
         go install github.com/securego/gosec/v2/cmd/gosec@latest
         go install github.com/cucumber/godog/cmd/godog@latest
@@ -61,4 +60,4 @@ jobs:
         cd ./integrationtest
         npm ci
 
-        $(npm bin)/fabric-chaincode-integration run
+        npx fabric-chaincode-integration run

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -9,11 +9,11 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
-          go-version: '^1.20'
+          go-version: "1.21"
           check-latest: true
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/integrationtest/Dockerfile
+++ b/integrationtest/Dockerfile
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG GO_VER=1.19
-ARG ALPINE_VER=3.16
 
-FROM golang:${GO_VER}-alpine${ALPINE_VER}
+FROM golang:${GO_VER}
 
 WORKDIR $GOPATH/src/github.com/hyperledger/fabric-contract-api-go
 COPY . .


### PR DESCRIPTION
- Use non-deprecated GitHub actions, avoiding ones based on Node 16.
- Use supported (Debian-based) Golang Docker images.
- Use Ubuntu 22.04