### PR TITLE
Fix gosec failures on integer conversion

### DIFF
--- a/internal/functionaltests/contracts/complexcontract/complexcontract.go
+++ b/internal/functionaltests/contracts/complexcontract/complexcontract.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math"
 
 	"github.com/hyperledger/fabric-contract-api-go/v2/contractapi"
 	"github.com/hyperledger/fabric-contract-api-go/v2/internal/functionaltests/contracts/utils"
@@ -89,7 +90,10 @@ func (c *ComplexContract) UpdateValue(ctx utils.CustomTransactionContextInterfac
 		return fmt.Errorf("data retrieved from world state for key %s was not of type BasicObject", id)
 	}
 
-	newValue := int(ba.Value) + valueAdd
+	if ba.Value > math.MaxInt {
+		return errors.New("%d overflows an int")
+	}
+	newValue := int(ba.Value) + valueAdd // #nosec G115
 
 	if newValue < 0 {
 		newValue = 0

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -79,7 +79,7 @@ func (it *int8Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int8", value)
 		}
 
-		intVal = int8(int64val)
+		intVal = int8(int64val) // #nosec G115
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -100,7 +100,7 @@ func (it *int16Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int16", value)
 		}
 
-		intVal = int16(int64val)
+		intVal = int16(int64val) // #nosec G115
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -121,7 +121,7 @@ func (it *int32Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int32", value)
 		}
 
-		intVal = int32(int64val)
+		intVal = int32(int64val) // #nosec G115
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -191,7 +191,7 @@ func (ut *uint8Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint8", value)
 		}
 
-		uintVal = uint8(uint64Val)
+		uintVal = uint8(uint64Val) // #nosec G115
 	}
 
 	return reflect.ValueOf(uintVal), nil
@@ -217,7 +217,7 @@ func (ut *uint16Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint16", value)
 		}
 
-		uintVal = uint16(uint64Val)
+		uintVal = uint16(uint64Val) // #nosec G115
 	}
 
 	return reflect.ValueOf(uintVal), nil
@@ -243,7 +243,7 @@ func (ut *uint32Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint32", value)
 		}
 
-		uintVal = uint32(uint64Val)
+		uintVal = uint32(uint64Val) // #nosec G115
 	}
 
 	return reflect.ValueOf(uintVal), nil


### PR DESCRIPTION
New versions of gosec implemented stricter type conversion and bounds checks.