### PR TITLE
More numeric type conversion lint fixes

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -3,6 +3,7 @@ name: Scheduled build
 on:
   schedule:
     - cron: "23 03 * * 0"
+  workflow_dispatch:
 
 jobs:
   main:

--- a/internal/functionaltests/contracts/complexcontract/complexcontract.go
+++ b/internal/functionaltests/contracts/complexcontract/complexcontract.go
@@ -90,16 +90,14 @@ func (c *ComplexContract) UpdateValue(ctx utils.CustomTransactionContextInterfac
 		return fmt.Errorf("data retrieved from world state for key %s was not of type BasicObject", id)
 	}
 
-	if ba.Value > math.MaxInt {
-		return errors.New("%d overflows an int")
+	newValue := float64(ba.Value) + float64(valueAdd)
+	if newValue > math.MaxUint {
+		return fmt.Errorf("%f overflows an unsigned int", newValue)
+	} else if newValue <= 0 {
+		ba.Value = 0
+	} else {
+		ba.Value = uint(newValue)
 	}
-	newValue := int(ba.Value) + valueAdd // #nosec G115
-
-	if newValue < 0 {
-		newValue = 0
-	}
-
-	ba.Value = uint(newValue)
 
 	baBytes, _ := json.Marshal(ba)
 

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -79,7 +79,7 @@ func (it *int8Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int8", value)
 		}
 
-		intVal = int8(int64val) // #nosec G115
+		intVal = int8(int64val)
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -100,7 +100,7 @@ func (it *int16Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int16", value)
 		}
 
-		intVal = int16(int64val) // #nosec G115
+		intVal = int16(int64val)
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -121,7 +121,7 @@ func (it *int32Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to int32", value)
 		}
 
-		intVal = int32(int64val) // #nosec G115
+		intVal = int32(int64val)
 	}
 
 	return reflect.ValueOf(intVal), nil
@@ -191,7 +191,7 @@ func (ut *uint8Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint8", value)
 		}
 
-		uintVal = uint8(uint64Val) // #nosec G115
+		uintVal = uint8(uint64Val)
 	}
 
 	return reflect.ValueOf(uintVal), nil
@@ -217,7 +217,7 @@ func (ut *uint16Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint16", value)
 		}
 
-		uintVal = uint16(uint64Val) // #nosec G115
+		uintVal = uint16(uint64Val)
 	}
 
 	return reflect.ValueOf(uintVal), nil
@@ -243,7 +243,7 @@ func (ut *uint32Type) Convert(value string) (reflect.Value, error) {
 			return reflect.Value{}, fmt.Errorf("cannot convert passed value %s to uint32", value)
 		}
 
-		uintVal = uint32(uint64Val) // #nosec G115
+		uintVal = uint32(uint64Val)
 	}
 
 	return reflect.ValueOf(uintVal), nil


### PR DESCRIPTION
Newer versions of gosec implement more checks and guard detection for numeric type conversions. This allows some suppressions to be removed and more thorough guards to be used.