### PR TITLE
upgrading the base image

### DIFF
--- a/integrationtest/Dockerfile
+++ b/integrationtest/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright the Hyperledger Fabric contributors. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-ARG GO_VER=1.21
+ARG GO_VER=1.23.0
 
 FROM golang:${GO_VER}
 


### PR DESCRIPTION
Upgrading base image in 


Current image  `golang:1.21` TO Minor upgrades `golang:1.23.0`