### PR TITLE
Run vulnerability scan on latest release version

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -14,6 +14,9 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
 
+  scan:
+    uses: ./.github/workflows/scan.yml
+
   pull-request:
     needs: build
     name: Pull request success

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,25 @@
+name: "Security vulnerability scan"
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Branch, tag or SHA to scan.
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          check-latest: true
+      - name: Scan
+        run: make scan

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -6,14 +6,18 @@ on:
   workflow_dispatch:
 
 jobs:
-  scan:
+  latest-release-version:
+    name: Get latest release tag
     runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.tag-name.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version: stable
-          check-latest: true
-      - name: Scan
-        run: make scan
+      - id: tag-name
+        run: echo "value=$(curl --location --silent --fail "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"
+
+  scan:
+    name: Scan ${{ needs.latest-release-version.outputs.tag_name }}
+    needs: latest-release-version
+    uses: ./.github/workflows/scan.yml
+    with:
+      ref: ${{ needs.latest-release-version.outputs.tag_name }}


### PR DESCRIPTION
Previously the scan ran on the current state of the codebase. This fails to identify vulnerabilities in dependencies for the latest release version if those dependencies have already been updated in the development codebase. The gating factor for whether a new release is required should be whether the previous release contains vulnerabilities.

This change runs the scheduled vulnerability scan on the latest release tag. It also adds vulnerability scanning to pull request builds. This is purely informational. A scan failure does not fail the pull request build.