### PR TITLE
fix: It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.

### DIFF
--- a/integrationtest/chaincode/private/main.go
+++ b/integrationtest/chaincode/private/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/hyperledger/fabric-contract-api-go/v2/contractapi"
 )
@@ -28,7 +29,7 @@ func (sc *PrivateContract) GetPrivateState(ctx contractapi.TransactionContextInt
 	}
 
 	if bytes == nil {
-		return "", errors.New("No value found for " + key)
+		return "", fmt.Errorf("No value found for " + key)
 	}
 
 	return string(bytes), nil


### PR DESCRIPTION
It is recommended to use the fmt.Errorf method with parameters instead of the errors.New method without parameters.