### PR TITLE
Bump axios to 1.8.2

### DIFF
--- a/integrationtest/package-lock.json
+++ b/integrationtest/package-lock.json
@@ -624,9 +624,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -3621,9 +3621,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axios": {
-      "version": "1.7.9",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.9.tgz",
-      "integrity": "sha512-LhLcE7Hbiryz8oMDdDptSrWowmB4Bl6RCt6sIJKpRB4XtVf0iEgewX3au/pJqm+Py1kCASkb/FFKjxQaLtxJvw==",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
+      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -4709,7 +4709,7 @@
       "resolved": "https://registry.npmjs.org/nano/-/nano-10.1.4.tgz",
       "integrity": "sha512-bJOFIPLExIbF6mljnfExXX9Cub4W0puhDjVMp+qV40xl/DBvgKao7St4+6/GB6EoHZap7eFnrnx4mnp5KYgwJA==",
       "requires": {
-        "axios": "^1.7.4",
+        "axios": "^1.8.2",
         "node-abort-controller": "^3.1.1",
         "qs": "^6.13.0"
       }

--- a/integrationtest/package.json
+++ b/integrationtest/package.json
@@ -3,6 +3,9 @@
     "@hyperledger/fabric-chaincode-integration": "^0.8.4",
     "@hyperledger/fabric-gateway": "^1.5.0"
   },
+  "overrides": {
+    "axios": "^1.8.2"
+  }, 
   "scripts": {
     "test": "fabric-chaincode-integration"
   }


### PR DESCRIPTION
https://github.com/advisories/GHSA-jr5f-v2jv-69x6 - https://cve.mitre.org/cgi-bin/cvename.cgi?name=2025-27152

axios is pulled in by transitive dependency on @hyperledger/fabric-chaincode-integration and nano.
nano has not yet updated axios version.
In the meantime we can update axios dependency with an override.