### PR TITLE
Use OSV-Scanner v2 for vulnerability scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -17,9 +17,25 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
       - name: Set up Go
+        id: setup-go
         uses: actions/setup-go@v5
         with:
           go-version: stable
           check-latest: true
+      - name: Create OSV-Scanner config
+        run: |
+          echo "GoVersionOverride = '${{ steps.setup-go.outputs.go-version }}'" > osv-scanner.toml
       - name: Scan
-        run: make scan
+        id: scan-go
+        run: |
+          docker run --rm \
+            --volume './:/src' \
+            ghcr.io/google/osv-scanner:latest \
+            scan \
+            --config=/src/osv-scanner.toml \
+            --lockfile=/src/go.mod \
+            --format=markdown > osv-scanner.md
+      - name: Report failure
+        if: ${{ failure() && steps.scan-go.conclusion == 'failure' }}
+        run: |
+          cat osv-scanner.md >> ${GITHUB_STEP_SUMMARY}

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ ifeq ($(machine_hardware), aarch64)
 	machine_hardware := arm64
 endif
 
+TMPDIR ?= /tmp
+TMPDIR := $(abspath $(TMPDIR))
+
 .PHONY: test
 test: generate lint unit-test functional-test
 
@@ -52,5 +55,6 @@ functional-test:
 
 .PHONY: scan
 scan:
-	go install golang.org/x/vuln/cmd/govulncheck@latest
-	cd '$(base_dir)' && govulncheck ./...
+	go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+	echo "GoVersionOverride = '$$(go env GOVERSION | sed -e 's/^go//' -e 's/-.*//')'" > '$(TMPDIR)/osv-scanner.toml'
+	osv-scanner scan --config='$(TMPDIR)/osv-scanner.toml' --lockfile='$(base_dir)/go.mod'


### PR DESCRIPTION
- Use Docker image in actions workflow since this is much faster.
- Override Go version from go.mod with local Go version to avoid false positives from back-level Go standard libraries. Consumers are expected to use current Go version, even if older versions are allowable.