### PR TITLE
CVE-2025-58754 | update axios to 1.12.2

### DIFF
--- a/integrationtest/package-lock.json
+++ b/integrationtest/package-lock.json
@@ -4,10 +4,10 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "integrationtest",
       "dependencies": {
         "@hyperledger/fabric-chaincode-integration": "^0.8.4",
-        "@hyperledger/fabric-gateway": "^1.5.0",
-        "form-data": "^4.0.4"
+        "@hyperledger/fabric-gateway": "^1.5.0"
       }
     },
     "node_modules/@colors/colors": {
@@ -625,13 +625,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -3624,12 +3624,12 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "axios": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.2.tgz",
-      "integrity": "sha512-ls4GYBm5aig9vWx8AWDSGLpnpDQRtWAfrjU+EuytuODrFBkqesN2RkOQCBzrA1RQNHw1SmRMSDDDSwzNAYQ6Rg==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/integrationtest/package.json
+++ b/integrationtest/package.json
@@ -4,7 +4,7 @@
     "@hyperledger/fabric-gateway": "^1.5.0"
   },
   "overrides": {
-    "axios": "^1.8.2",
+    "axios": "^1.12.2",
     "form-data": "^4.0.4"
   },
   "scripts": {


### PR DESCRIPTION
CVE-2025-58754 - update axios to 1.12.2 with npm audit fix command