### PR TITLE
Use reflect.Pointer instead of reflect.Ptr

### DIFF
--- a/internal/types_handler.go
+++ b/internal/types_handler.go
@@ -38,7 +38,7 @@ func arrayOfValidType(array reflect.Value, additionalTypes []reflect.Type) error
 }
 
 func structOfValidType(obj reflect.Type, additionalTypes []reflect.Type) error {
-	if obj.Kind() == reflect.Ptr {
+	if obj.Kind() == reflect.Pointer {
 		obj = obj.Elem()
 	}
 
@@ -89,7 +89,7 @@ func typeIsValid(t reflect.Type, additionalTypes []reflect.Type, allowError bool
 			additionalTypes = append(additionalTypes, reflect.PointerTo(t))
 			// add self for cyclic
 			return structOfValidType(t, additionalTypes)
-		} else if kind == reflect.Ptr && t.Elem().Kind() == reflect.Struct {
+		} else if kind == reflect.Pointer && t.Elem().Kind() == reflect.Struct {
 			additionalTypes = append(additionalTypes, t)
 			additionalTypes = append(additionalTypes, t.Elem())
 			// add self for cyclic

--- a/metadata/schema.go
+++ b/metadata/schema.go
@@ -49,7 +49,7 @@ func getSchema(field reflect.Type, components *ComponentMetadata, nested bool) (
 		return buildMapSchema(reflect.MakeMap(field), components, nested)
 	}
 
-	if field.Kind() == reflect.Struct || (field.Kind() == reflect.Ptr && field.Elem().Kind() == reflect.Struct) {
+	if field.Kind() == reflect.Struct || (field.Kind() == reflect.Pointer && field.Elem().Kind() == reflect.Struct) {
 		return buildStructSchema(field, components, nested)
 	}
 
@@ -95,7 +95,7 @@ func buildMapSchema(rmap reflect.Value, components *ComponentMetadata, nested bo
 }
 
 func addComponentIfNotExists(obj reflect.Type, components *ComponentMetadata) error {
-	if obj.Kind() == reflect.Ptr {
+	if obj.Kind() == reflect.Pointer {
 		obj = obj.Elem()
 	}
 
@@ -193,7 +193,7 @@ func getField(field reflect.StructField, schema *ObjectMetadata, components *Com
 }
 
 func buildStructSchema(obj reflect.Type, components *ComponentMetadata, nested bool) (*spec.Schema, error) {
-	if obj.Kind() == reflect.Ptr {
+	if obj.Kind() == reflect.Pointer {
 		obj = obj.Elem()
 	}
 

--- a/serializer/json_transaction_serializer.go
+++ b/serializer/json_transaction_serializer.go
@@ -106,7 +106,7 @@ func convertArg(fieldType reflect.Type, paramValue string) (reflect.Value, error
 		converted = reflect.ValueOf(t)
 	} else if types.IsBytes(fieldType) {
 		converted = reflect.ValueOf([]byte(paramValue))
-	} else if fieldType.Kind() == reflect.Array || fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Map || fieldType.Kind() == reflect.Struct || (fieldType.Kind() == reflect.Ptr && fieldType.Elem().Kind() == reflect.Struct) {
+	} else if fieldType.Kind() == reflect.Array || fieldType.Kind() == reflect.Slice || fieldType.Kind() == reflect.Map || fieldType.Kind() == reflect.Struct || (fieldType.Kind() == reflect.Pointer && fieldType.Elem().Kind() == reflect.Struct) {
 		converted, err = createArraySliceMapOrStruct(paramValue, fieldType)
 	} else {
 		converted, err = types.BasicTypes[fieldType.Kind()].Convert(paramValue)
@@ -124,7 +124,7 @@ func validateAgainstSchema(propName string, typ reflect.Type, stringValue string
 
 	if typ == reflect.TypeOf(time.Time{}) {
 		toValidate[propName] = stringValue
-	} else if typ.Kind() == reflect.Struct || (typ.Kind() == reflect.Ptr && typ.Elem().Kind() == reflect.Struct) {
+	} else if typ.Kind() == reflect.Struct || (typ.Kind() == reflect.Pointer && typ.Elem().Kind() == reflect.Struct) {
 		// use a map for structs as schema seems to like that
 		structMap := make(map[string]interface{})
 		if err := json.Unmarshal([]byte(stringValue), &structMap); err != nil {
@@ -147,10 +147,10 @@ func validateAgainstSchema(propName string, typ reflect.Type, stringValue string
 }
 
 func isNillableType(kind reflect.Kind) bool {
-	return kind == reflect.Ptr || kind == reflect.Interface || kind == reflect.Map || kind == reflect.Slice || kind == reflect.Chan || kind == reflect.Func
+	return kind == reflect.Pointer || kind == reflect.Interface || kind == reflect.Map || kind == reflect.Slice || kind == reflect.Chan || kind == reflect.Func
 }
 
 func isMarshallingType(typ reflect.Type) bool {
 	return !types.IsBytes(typ) &&
-		(typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Map || typ.Kind() == reflect.Struct || (typ.Kind() == reflect.Ptr && isMarshallingType(typ.Elem())))
+		(typ.Kind() == reflect.Array || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Map || typ.Kind() == reflect.Struct || (typ.Kind() == reflect.Pointer && isMarshallingType(typ.Elem())))
 }


### PR DESCRIPTION
reflect.Pointer replaced reflect.Ptr in Go 1.18. For backwards compatibility, reflect.Ptr is a constant with the value of reflect.Pointer. The use of this constant triggers a (false positive) lint failure as it should be inlined. This can be avoided by using the preferred reflect.Pointer constant.