### PR TITLE
GHSA-q6x5-8v7m-xcrf | bump protobufjs to >=7.5.6

### DIFF
--- a/integrationtest/package-lock.json
+++ b/integrationtest/package-lock.json
@@ -4,11 +4,15 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "integrationtest",
       "dependencies": {
         "@hyperledger/fabric-chaincode-integration": "^0.8.4",
-        "@hyperledger/fabric-gateway": "^1.10.1",
-        "axios": "^1.15.2"
+        "@hyperledger/fabric-gateway": "^1.10.1"
+      },
+      "overrides": {
+        "axios": "^1.15.2",
+        "form-data": "^4.0.4",
+        "protobufjs": "^7.5.6",
+        "qs": "^6.14.1"
       }
     },
     "node_modules/@colors/colors": {
@@ -3357,7 +3361,7 @@
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
-        "protobufjs": "^7.5.3",
+        "protobufjs": "^7.5.6",
         "yargs": "^17.7.2"
       }
     },
@@ -4632,7 +4636,7 @@
       "resolved": "https://registry.npmjs.org/nano/-/nano-10.1.4.tgz",
       "integrity": "sha512-bJOFIPLExIbF6mljnfExXX9Cub4W0puhDjVMp+qV40xl/DBvgKao7St4+6/GB6EoHZap7eFnrnx4mnp5KYgwJA==",
       "requires": {
-        "axios": "^1.7.4",
+        "axios": "^1.15.2",
         "node-abort-controller": "^3.1.1",
         "qs": "^6.14.1"
       }

--- a/integrationtest/package.json
+++ b/integrationtest/package.json
@@ -6,6 +6,7 @@
   "overrides": {
     "axios": "^1.15.2",
     "form-data": "^4.0.4",
+    "protobufjs": "^7.5.6",
     "qs": "^6.14.1"
   },
   "scripts": {


### PR DESCRIPTION
Add protobufjs override to enforce minimum safe version across all transitive dependencies, addressing the prototype pollution vulnerability reported in GHSA-q6x5-8v7m-xcrf (affects protobufjs < 7.3.3).